### PR TITLE
valsamoggia.ninux.org remove obsolete lime-map-agent

### DIFF
--- a/valsamoggia.ninux.org/vs-ninux-generic/Makefile
+++ b/valsamoggia.ninux.org/vs-ninux-generic/Makefile
@@ -1,12 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PROFILE_DESCRIPTION:=Generic valsamoggia configuration
-PROFILE_DEPENDS:=+prometheus-node-exporter-lua \
-	+prometheus-node-exporter-lua-wifi \
-	+prometheus-node-exporter-lua-wifi_stations \
-	+prometheus-node-exporter-lua-openwrt \
-	+lime-system \
-	+lime-proto-babeld \
+PROFILE_DEPENDS:= +lime-proto-babeld \
 	+lime-proto-batadv \
 	+lime-proto-anygw \
 	+lime-proto-wan \
@@ -20,11 +15,9 @@ PROFILE_DEPENDS:=+prometheus-node-exporter-lua \
 	+shared-state-nodes_and_links \
 	+check-date-http \
 	+lime-app \
-	+lime-map-agent \
 	+lime-hwd-ground-routing \
 	+lime-debug \
-	+luci \
-	+luci-lib-libremap-babeld
+	+luci 
 
 include ../../profile.mk
 

--- a/valsamoggia.ninux.org/vs-ninux-generic/root/etc/config/lime-community
+++ b/valsamoggia.ninux.org/vs-ninux-generic/root/etc/config/lime-community
@@ -5,7 +5,7 @@ config lime system
 
 config lime network
 	option primary_interface 'eth0'
-	option main_ipv4_address '10.%N1.128.0/16/17'
+	option main_ipv4_address '10.170.128.0/16/17'
 	option anygw_dhcp_start '5120'
 	option anygw_dhcp_limit '27648'
 	option main_ipv6_address '2a00:1508:0a%N1:%N200::/64'


### PR DESCRIPTION
Remove obsolete package lime-map-agent

Now works only adding old feeds to feeds.conf
`src-git libremap https://github.com/libremesh/libremap-agent.git;master`
