### PR TITLE
valsamoggia.ninux.org move prometheus conf to lime-community, reinser…

### DIFF
--- a/valsamoggia.ninux.org/vs-ninux-generic/Makefile
+++ b/valsamoggia.ninux.org/vs-ninux-generic/Makefile
@@ -1,7 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PROFILE_DESCRIPTION:=Generic valsamoggia configuration
-PROFILE_DEPENDS:= +lime-proto-babeld \
+PROFILE_DEPENDS:= +prometheus-node-exporter-lua \
+	+prometheus-node-exporter-lua-wifi \
+	+prometheus-node-exporter-lua-wifi_stations \
+	+prometheus-node-exporter-lua-openwrt \
+	+lime-proto-babeld \
 	+lime-proto-batadv \
 	+lime-proto-anygw \
 	+lime-proto-wan \
@@ -17,7 +21,7 @@ PROFILE_DEPENDS:= +lime-proto-babeld \
 	+lime-app \
 	+lime-hwd-ground-routing \
 	+lime-debug \
-	+luci 
+	+luci
 
 include ../../profile.mk
 

--- a/valsamoggia.ninux.org/vs-ninux-generic/root/etc/config/lime-community
+++ b/valsamoggia.ninux.org/vs-ninux-generic/root/etc/config/lime-community
@@ -33,3 +33,7 @@ config lime wifi
 	option apname_ssid 'ninux/%H'
 	option ieee80211s_mesh_fwding '0'
 	option ieee80211s_mesh_id 'LiMe'
+
+config generic_uci_config prometheus
+	list uci_set "prometheus-node-exporter-lua.main.listen_ipv6=0"
+	list uci_set "prometheus-node-exporter-lua.main.listen_port=9100"

--- a/valsamoggia.ninux.org/vs-ninux-generic/root/etc/config/prometheus-node-exporter-lua
+++ b/valsamoggia.ninux.org/vs-ninux-generic/root/etc/config/prometheus-node-exporter-lua
@@ -1,3 +1,0 @@
-config prometheus-node-exporter-lua 'main'
-    option listen_address '::'
-    option listen_port '9100'

--- a/valsamoggia.ninux.org/vs-ninux-generic/root/etc/uci-defaults/99-prometheus_enable
+++ b/valsamoggia.ninux.org/vs-ninux-generic/root/etc/uci-defaults/99-prometheus_enable
@@ -1,4 +1,0 @@
-#!/bin/sh
-[ -x /etc/init.d/prometheus-node-exporter-lua ] &&
-	/etc/init.d/prometheus-node-exporter-lua enable
-exit 0


### PR DESCRIPTION
Thanks very much for this: https://github.com/libremesh/network-profiles/pull/73#issuecomment-846440769

Ok I used the first one, I actually keep the default configuration for promethues-node-exporter-lua, but I've checked that the file in /etc/config/ is modified correctly from the generic_uci_config directive
And now the build with this profile go on without fail

I'm not using uci-defaults scripts that would be then like this below, and I also removed a preexistent scripts in uci-defaults/ for enabling prometheus-node-exporter-lua
because it seems that this result yet enabled and running at startup just selecting it in the menuconfig or through the Makefile 

```
#!/bin/sh

uci set prometheus-node-exporter-lua.main.listen_ipv6=0
uci set prometheus-node-exporter-lua.main.listen_port=9100
uci commit prometheus-node-exporter-lua

[ -x /etc/init.d/prometheus-node-exporter-lua ] &&
	/etc/init.d/prometheus-node-exporter-lua enable
exit 0
```
