### PR TITLE
quintanalibre: support adhoc and mesh

### DIFF
--- a/quintanalibre.org.ar/generic/files/etc/config/lime-community
+++ b/quintanalibre.org.ar/generic/files/etc/config/lime-community
@@ -8,6 +8,7 @@ config lime network
 	option main_ipv6_address '2801:01e8:2::/64'
 
 	list protocols adhoc
+	list protocols 'ieee80211s'
 	list protocols lan
 	list protocols anygw
 	list protocols batadv:%N1
@@ -32,6 +33,7 @@ config lime wifi
 	list modes 'ap_2ghz'
 	list modes 'apname_2ghz'
 	list modes 'adhoc'
+	list modes 'ieee80211s'
 
 	option ap_ssid 'quintana.libre.org.ar'
 	option apname_ssid 'quintana.libre.org.ar/%H'


### PR DESCRIPTION
To migrate the network from adhoc to mesh lets enable both protocols. This setup has been working in ql-flor and ql-czuk for months