### PR TITLE
Deleted non-existing packages

### DIFF
--- a/es.hackmeeting.org/hm2019generic/Makefile
+++ b/es.hackmeeting.org/hm2019generic/Makefile
@@ -26,9 +26,7 @@ PROFILE_DEPENDS:=+prometheus-node-exporter-lua \
 +lime-hwd-ground-routing                       \
 +lime-debug                                    \
 +ubus-lime-batman-adv                          \
-+ubus-lime-fbw                                 \
 +pirania                                       \
-+pirania-app                                   \
 +shared-state-pirania                          \
 +shared-state-persist
 


### PR DESCRIPTION
Some packages have disappeared, and this caused a harmless warning to appear when using the buildroot:

```
WARNING: Makefile 'package/feeds/profiles/hm2019generic/Makefile' has a dependency on 'ubus-lime-fbw', which does not exist
WARNING: Makefile 'package/feeds/profiles/hm2019generic/Makefile' has a dependency on 'pirania-app', which does not exist
```