### PR TITLE
freifunk: don't pull uhttpd-mod-lua

### DIFF
--- a/freifunk/80211s-sae-batadv-only/Makefile
+++ b/freifunk/80211s-sae-batadv-only/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PROFILE_DESCRIPTION:=Use 802.11s with SAE for mesh, route with batman-adv only
-PROFILE_DEPENDS:+wpad-mesh-wolfssl +lime-proto-batadv +lime-proto-anygw +uhttpd-mod-lua +shared-state +shared-state-bat_hosts +shared-state-dnsmasq_hosts +shared-state-dnsmasq_leases
+PROFILE_DEPENDS:=+wpad-mesh-wolfssl +lime-proto-batadv +lime-proto-anygw +shared-state +shared-state-bat_hosts +shared-state-dnsmasq_hosts +shared-state-dnsmasq_leases +wifi-unstuck-wa
 
 include ../../profile.mk
 

--- a/freifunk/80211s-sae-bmx7-batadv/Makefile
+++ b/freifunk/80211s-sae-bmx7-batadv/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PROFILE_DESCRIPTION:=Use 802.11s with SAE for mesh, route with bmx7 and batman-adv
-PROFILE_DEPENDS:=+wpad-mesh-wolfssl +wpa-cli +bmx7 +bmx7-iwinfo +bmx7-json +bmx7-sms +bmx7-table +bmx7-tun +bmx7-uci-config +lime-proto-batadv +bmx7-auto-gw-mode +lime-proto-bmx7 +lime-proto-anygw +uhttpd-mod-lua +shared-state +shared-state-dnsmasq_hosts +shared-state-dnsmasq_leases +shared-state-bat_hosts +wifi-unstuck-wa
+PROFILE_DEPENDS:=+wpad-mesh-wolfssl +wpa-cli +bmx7 +bmx7-iwinfo +bmx7-json +bmx7-sms +bmx7-table +bmx7-tun +bmx7-uci-config +lime-proto-batadv +bmx7-auto-gw-mode +lime-proto-bmx7 +lime-proto-anygw +shared-state +shared-state-dnsmasq_hosts +shared-state-dnsmasq_leases +shared-state-bat_hosts +wifi-unstuck-wa
 
 include ../../profile.mk
 

--- a/freifunk/80211s-sae-bmx7-only/Makefile
+++ b/freifunk/80211s-sae-bmx7-only/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PROFILE_DESCRIPTION:=Use 802.11s with SAE for mesh, route with bmx7 only
-PROFILE_DEPENDS:=+wpad-mesh-wolfssl +wpa-cli +bmx7 +bmx7-iwinfo +bmx7-json +bmx7-sms +bmx7-table +bmx7-tun +bmx7-uci-config +bmx7-auto-gw-mode +lime-proto-bmx7 +lime-proto-anygw +uhttpd-mod-lua +shared-state +shared-state-dnsmasq_hosts +shared-state-dnsmasq_leases +wifi-unstuck-wa
+PROFILE_DEPENDS:=+wpad-mesh-wolfssl +wpa-cli +bmx7 +bmx7-iwinfo +bmx7-json +bmx7-sms +bmx7-table +bmx7-tun +bmx7-uci-config +bmx7-auto-gw-mode +lime-proto-bmx7 +lime-proto-anygw +shared-state +shared-state-dnsmasq_hosts +shared-state-dnsmasq_leases +wifi-unstuck-wa
 
 include ../../profile.mk
 


### PR DESCRIPTION
Dependencies in LiMe became more complex which lead to several circular dependencies. Remove dependency on 'uhttpd-mod-lua' to hopefully resolve this issue for the freifunk community profiles.

This should fix #83.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>