### PR TITLE
Added first version of network profiles for Calafou

### DIFF
--- a/calafou/indoor-crypt/Makefile
+++ b/calafou/indoor-crypt/Makefile
@@ -1,0 +1,25 @@
+include $(TOPDIR)/rules.mk
+
+PROFILE_DESCRIPTION:=Encryptable mesh and AP for Calafou indoor nodes
+PROFILE_DEPENDS:=+deferable-reboot +safe-reboot +wpad-full-openssl \
+	+lime-docs \
+	+lime-proto-babeld \
+	+lime-proto-batadv \
+	+lime-proto-anygw \
+	+lime-hwd-openwrt-wan \
+	+shared-state \
+	+hotplug-initd-services \
+	+shared-state-babeld_hosts \
+	+shared-state-bat_hosts \
+	+shared-state-dnsmasq_hosts \
+	+shared-state-dnsmasq_leases \
+	+shared-state-nodes_and_links \
+	+check-date-http \
+	+lime-app \
+	+lime-hwd-ground-routing \
+	+lime-debug \
+	+babeld-auto-gw-mode
+
+include ../../profile.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/calafou/indoor-crypt/root/etc/config/lime-community
+++ b/calafou/indoor-crypt/root/etc/config/lime-community
@@ -1,0 +1,26 @@
+config lime system
+	option deferable_reboot_uptime_s '654321' # reboot every 7.5 days 
+
+config lime network
+	option main_ipv4_address '10.1.0.0/16/17'
+	option anygw_dhcp_start '2562'
+	option anygw_dhcp_limit '30205'
+
+config lime wifi		
+	option country 'ES'	
+	option ap_ssid 'Calafou'
+	option apname_ssid 'Calafou/%H'
+	option ieee80211s_mesh_id 'libremesh'
+
+config lime-wifi-band '2ghz' 
+	option channel '1'
+	list modes 'ap'	
+	list modes 'apname'
+	list modes 'ieee80211s'
+
+config lime-wifi-band '5ghz'
+	option channel '40'
+	list modes 'ap'	
+	list modes 'apname'
+	list modes 'ieee80211s'
+

--- a/calafou/indoor-open/Makefile
+++ b/calafou/indoor-open/Makefile
@@ -1,0 +1,25 @@
+include $(TOPDIR)/rules.mk
+
+PROFILE_DESCRIPTION:=Open mesh and AP for Calafou indoor nodes
+PROFILE_DEPENDS:=+deferable-reboot +safe-reboot \
+	+lime-docs \
+	+lime-proto-babeld \
+	+lime-proto-batadv \
+	+lime-proto-anygw \
+	+lime-hwd-openwrt-wan \
+	+shared-state \
+	+hotplug-initd-services \
+	+shared-state-babeld_hosts \
+	+shared-state-bat_hosts \
+	+shared-state-dnsmasq_hosts \
+	+shared-state-dnsmasq_leases \
+	+shared-state-nodes_and_links \
+	+check-date-http \
+	+lime-app \
+	+lime-hwd-ground-routing \
+	+lime-debug \
+	+babeld-auto-gw-mode
+
+include ../../profile.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/calafou/indoor-open/root/etc/config/lime-community
+++ b/calafou/indoor-open/root/etc/config/lime-community
@@ -1,0 +1,26 @@
+config lime system
+	option deferable_reboot_uptime_s '654321' # reboot every 7.5 days 
+
+config lime network
+	option main_ipv4_address '10.1.0.0/16/17'
+	option anygw_dhcp_start '2562'
+	option anygw_dhcp_limit '30205'
+
+config lime wifi		
+	option country 'ES'	
+	option ap_ssid 'Calafou'
+	option apname_ssid 'Calafou/%H'
+	option ieee80211s_mesh_id 'libremesh'
+
+config lime-wifi-band '2ghz' 
+	option channel '1'
+	list modes 'ap'	
+	list modes 'apname'
+	list modes 'ieee80211s'
+
+config lime-wifi-band '5ghz'
+	option channel '40'
+	list modes 'ap'	
+	list modes 'apname'
+	list modes 'ieee80211s'
+

--- a/calafou/outdoor-crypt/Makefile
+++ b/calafou/outdoor-crypt/Makefile
@@ -1,0 +1,25 @@
+include $(TOPDIR)/rules.mk
+
+PROFILE_DESCRIPTION:=Encryptable mesh and AP for Calafou outdoor nodes
+PROFILE_DEPENDS:=+deferable-reboot +safe-reboot +wpad-full-openssl \
+	+lime-docs \
+	+lime-proto-babeld \
+	+lime-proto-batadv \
+	+lime-proto-anygw \
+	+lime-hwd-openwrt-wan \
+	+shared-state \
+	+hotplug-initd-services \
+	+shared-state-babeld_hosts \
+	+shared-state-bat_hosts \
+	+shared-state-dnsmasq_hosts \
+	+shared-state-dnsmasq_leases \
+	+shared-state-nodes_and_links \
+	+check-date-http \
+	+lime-app \
+	+lime-hwd-ground-routing \
+	+lime-debug \
+	+babeld-auto-gw-mode
+
+include ../../profile.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/calafou/outdoor-crypt/root/etc/config/lime-community
+++ b/calafou/outdoor-crypt/root/etc/config/lime-community
@@ -1,0 +1,24 @@
+config lime system
+	option deferable_reboot_uptime_s '654321' # reboot every 7.5 days 
+
+config lime network
+	option main_ipv4_address '10.1.0.0/16/17'
+	option anygw_dhcp_start '2562'
+	option anygw_dhcp_limit '30205'
+
+config lime wifi		
+	option country 'ES'	
+	option ap_ssid 'Calafou'
+	option apname_ssid 'Calafou/%H'
+	option ieee80211s_mesh_id 'libremesh'
+
+config lime-wifi-band '2ghz' 
+	option channel '6'
+	list modes 'ap'	
+	list modes 'apname'
+	list modes 'ieee80211s'
+
+config lime-wifi-band '5ghz'
+	option channel '64'
+	list modes 'ieee80211s'
+

--- a/calafou/outdoor-open/Makefile
+++ b/calafou/outdoor-open/Makefile
@@ -1,0 +1,25 @@
+include $(TOPDIR)/rules.mk
+
+PROFILE_DESCRIPTION:=Open mesh and AP for Calafou outdoor nodes
+PROFILE_DEPENDS:=+deferable-reboot +safe-reboot \
+	+lime-docs \
+	+lime-proto-babeld \
+	+lime-proto-batadv \
+	+lime-proto-anygw \
+	+lime-hwd-openwrt-wan \
+	+shared-state \
+	+hotplug-initd-services \
+	+shared-state-babeld_hosts \
+	+shared-state-bat_hosts \
+	+shared-state-dnsmasq_hosts \
+	+shared-state-dnsmasq_leases \
+	+shared-state-nodes_and_links \
+	+check-date-http \
+	+lime-app \
+	+lime-hwd-ground-routing \
+	+lime-debug \
+	+babeld-auto-gw-mode
+
+include ../../profile.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/calafou/outdoor-open/root/etc/config/lime-community
+++ b/calafou/outdoor-open/root/etc/config/lime-community
@@ -1,0 +1,24 @@
+config lime system
+	option deferable_reboot_uptime_s '654321' # reboot every 7.5 days 
+
+config lime network
+	option main_ipv4_address '10.1.0.0/16/17'
+	option anygw_dhcp_start '2562'
+	option anygw_dhcp_limit '30205'
+
+config lime wifi		
+	option country 'ES'	
+	option ap_ssid 'Calafou'
+	option apname_ssid 'Calafou/%H'
+	option ieee80211s_mesh_id 'libremesh'
+
+config lime-wifi-band '2ghz' 
+	option channel '6'
+	list modes 'ap'	
+	list modes 'apname'
+	list modes 'ieee80211s'
+
+config lime-wifi-band '5ghz'
+	option channel '64'
+	list modes 'ieee80211s'
+


### PR DESCRIPTION
The differences between the 4 profiles are small:

the indoor ones have AP also on 5 GHz that the outdoor ones do not have

we could disable mesh in the indoor profile, I left it in case we wanted to extend the coverage or large rooms using it...

the indoor ones use channels 1 and 40 while the outdoor ones use channels 6 and 64

the -crypt ones include wpad-full-openssl for being able to encrypt the ieee802.11s mesh and for having the option to set up Opportunistic Wireless Encryption instead of open access points

