### PR TITLE
fix: bump openwrt-sdk-action and init setup for apk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,27 +3,43 @@ name: Build network profiles
 on:
   push:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
+  # Build all packages for x86_64
+  # use latest branch of openwrt with opkg to produce feed at https://feed.libremesh.org/profiles
+  # use main branch of openwrt with apk to produce feed at https://feed.libremesh.org/apk/profiles
+  # NOTE: this doesn't sign packages for apk
   build:
+    name: Build profiles ${{ matrix.version }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        include:
+          - { version: main, output_path: 'apk/'}
+          - { version: openwrt-24.10, output_path: ''}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Build packages
+      - name: Build packages ${{ matrix.version }}
         uses: openwrt/gh-action-sdk@v7
         env:
-          ARCH: "x86_64-openwrt-23.05"
-          EXTRA_FEEDS: "src-git|libremesh|https://github.com/libremesh/lime-packages.git"
+          ARCH: "x86_64-${{ matrix.version }}"
           FEEDNAME: "profiles"
           IGNORE_ERRORS: "n m y"
-          KEY_BUILD: "${{ secrets.KEY_BUILD }}"
+          KEY_BUILD: "${{ matrix.version != 'main' && secrets.KEY_BUILD || '' }}"
+          INDEX: 1
+          NO_DEFAULT_FEEDS: 1
+          NO_REFRESH_CHECK: 1
+          NO_SHFMT_CHECK: 1
 
       - name: Upload packages to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           external_repository: libremesh/lime-feed
           publish_dir: bin/packages/x86_64/profiles/
-          destination_dir: profiles
+          destination_dir: ${{ matrix.output_path }}profiles

--- a/profile.mk
+++ b/profile.mk
@@ -6,24 +6,19 @@ PROFILE_COMMUNITY=$(lastword $(filter-out $(PROFILE_NAME),$(subst /, ,$(CURDIR))
 PKG_NAME:=profile-$(PROFILE_COMMUNITY)-$(PROFILE_NAME)
 PKG_MAINTAINER?=$(PROFILE_MAINTAINER)
 
-# from https://github.com/openwrt/luci/blob/master/luci.mk
+# from https://github.com/openwrt/luci/blob/master/luci.mk 
+# default package version follow this scheme:
+# [year].[day_of_year].[seconds_of_day]~[commit_short_hash] eg. 24.322.80622~a403707
 PKG_VERSION?=$(if $(DUMP),x,$(strip $(shell \
-	if svn info >/dev/null 2>/dev/null; then \
-		revision="svn-r$$(LC_ALL=C svn info | sed -ne 's/^Revision: //p')"; \
-	elif git log -1 >/dev/null 2>/dev/null; then \
-		revision="svn-r$$(LC_ALL=C git log -1 | sed -ne 's/.*git-svn-id: .*@\([0-9]\+\) .*/\1/p')"; \
-		if [ "$$revision" = "svn-r" ]; then \
-			set -- $$(git log -1 --format="%ct %h" --abbrev=7); \
-			secs="$$(($$1 % 86400))"; \
-			yday="$$(date --utc --date="@$$1" "+%y.%j")"; \
-			revision="$$(printf 'git-%s.%05d-%s' "$$yday" "$$secs" "$$2")"; \
-		fi; \
-	else \
-		revision="unknown"; \
-	fi; \
-	echo "$$revision" \
+    if git log -1 >/dev/null 2>/dev/null; then \
+      set -- $$(git log -1 --format="%ct %h" --abbrev=7); \
+        secs="$$(($$1 % 86400))"; \
+        yday="$$(date --utc --date="@$$1" "+%y.%j")"; \
+        printf '%s.%05d~%s' "$$yday" "$$secs" "$$2"; \
+    else \
+      echo "0"; \
+    fi; \
 )))
-PKG_RELEASE?=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -35,7 +30,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=LibreMesh
   TITLE:=$(if $(PROFILE_TITLE),$(PROFILE_TITLE),Profile $(PROFILE_COMMUNITY) $(PROFILE_NAME))
   DEPENDS:=+lime-system $(PROFILE_DEPENDS)
-  VERSION:=$(if $(PKG_VERSION),$(PKG_VERSION),$(PKG_SRC_VERSION))
+  VERSION:=$(PKG_VERSION)
   PKGARCH:=all
   URL:=https://github.com/libremesh/network-profiles/
 endef


### PR DESCRIPTION
similar to https://github.com/libremesh/lime-packages/pull/1139

profile.mk: drop svn check;
profile.mk: adapt default PKG_VERSION to be accepted by both opkg and apk .github/workflow/build.yml:
  bump actions/checkout from v2 to v4
  bump peaceiris/action-gh-pages from v3 to v4
  bump openwrt-sdk-action from v4 to v7 (that contain a fix to work with newer sdk snapshots)
  add on workflow_dispatch to be able to trigger the workflow from action tab (if ever needed)
  split build profiles to maintain the default repo with opkg https://feed.libremesh.org/profiles
  while creating a newer for apk (unsigned for now) https://feed.libremesh.org/apk/profiles
  add `NO_DEFAULT_FEEDS: 1` to speed up build process and avoid compile unneeded packages.

Tested on a ubnt_litebeam-m5-xw building with imagebuilder based on current openwrt-trunk Following readme instruction but replacing:
  sed -i 's|CONFIG_SIGNED_PACKAGES=y|# CONFIG_SIGNED_PACKAGES is not set|' .config
  sed -i 's|CONFIG_SIGNATURE_CHECK=y|# CONFIG_SIGNATURE_CHECK is not set|' .config
  sed -i 's|feed.libremesh.org|raw.githubusercontent.com/a-gave/lime-feed/refs/heads/gh-pages|g' repositories
  make image PROFILE=ubnt_litebeam-m5-xw PACKAGES="-ppp -ppp-mod-pppoe -kmod-ppp -kmod-pppoe -kmod-pppox \
    -odhcpd_ipv6only -dnsmasq profile-libremesh-suggested-packages-tiny batctl-default"

Then installing the sysupgrade to the device it is possible to install additional packages with:
  sed -i 's|http://feed.libremesh.org|https://raw.githubusercontent.com/a-gave/lime-feed/refs/heads/gh-pages|g' /etc/apk/repositories.d/limefeeds.list
  removing unsupported tags @libremesh @libremesh_arch_packages @libremesh_profiles
  apk update
  apk add --allow-untrusted lime-debug